### PR TITLE
feat: remove anyenv/pyenv and nodebrew setup

### DIFF
--- a/zsh/.zsh.d/anyenv.zsh
+++ b/zsh/.zsh.d/anyenv.zsh
@@ -1,2 +1,0 @@
-eval "$(anyenv init -)"
-eval "$(pyenv init -)"

--- a/zsh/.zsh.d/path.zsh
+++ b/zsh/.zsh.d/path.zsh
@@ -2,9 +2,6 @@
 export GOPATH=~/go
 export PATH=$GOPATH/bin:$PATH
 
-# Path to nodebrew
-export PATH=$HOME/.nodebrew/current/bin:$PATH
-
 export PATH="$HOME/dotfiles/bin:$PATH"
 export PATH="$HOME/dotfiles/bin/.secret:$PATH"
 export PATH="$HOME/.local/bin:$PATH"

--- a/zsh/.zsh.d/priorities.conf
+++ b/zsh/.zsh.d/priorities.conf
@@ -4,6 +4,5 @@ ZSH_CONFS=(
 "completion.zsh" \
 "zoxide.zsh" \
 "alias.zsh" \
-"anyenv.zsh" \
 "path.zsh" \
 )


### PR DESCRIPTION
## Summary
- anyenv/pyenvの初期化処理（`zsh/.zsh.d/anyenv.zsh`）を削除
- nodebrewのPATH設定（`zsh/.zsh.d/path.zsh`）を削除
- `zsh/.zsh.d/priorities.conf`から`anyenv.zsh`の読み込みを削除し、上記の削除と整合させる

## Test plan
- [x] `source ~/.zshrc` でエラーが出ないことを確認